### PR TITLE
Add --skip-disk-check flag to bypass iOS 26 space validation

### DIFF
--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -75,6 +75,7 @@
 static int verbose = 1;
 static int quit_flag = 0;
 static int passcode_requested = 0;
+static int skip_disk_check = 0;
 
 #define PRINT_VERBOSE(min_level, ...) \
 	if (verbose >= min_level)           \
@@ -1712,6 +1713,7 @@ int main(int argc, char *argv[])
 #define OPT_SKIP_APPS 7
 #define OPT_PASSWORD 8
 #define OPT_FULL 9
+#define OPT_SKIP_DISK_CHECK 10
 
 	int c = 0;
 	const struct option longopts[] = {
@@ -1732,6 +1734,7 @@ int main(int argc, char *argv[])
 			{"skip-apps", no_argument, NULL, OPT_SKIP_APPS},
 			{"password", required_argument, NULL, OPT_PASSWORD},
 			{"full", no_argument, NULL, OPT_FULL},
+			{"skip-disk-check", no_argument, NULL, OPT_SKIP_DISK_CHECK},
 			{NULL, 0, NULL, 0}};
 
 	/* we need to exit cleanly on running backups and restores or we cause havok */
@@ -1807,6 +1810,9 @@ int main(int argc, char *argv[])
 			break;
 		case OPT_FULL:
 			cmd_flags |= CMD_FLAG_FORCE_FULL_BACKUP;
+			break;
+		case OPT_SKIP_DISK_CHECK:
+			skip_disk_check = 1;
 			break;
 		default:
 			print_usage(argc, argv, 1);
@@ -2734,6 +2740,10 @@ int main(int argc, char *argv[])
 						freespace = (uint64_t)fs.f_bavail * (uint64_t)fs.f_frsize;
 					}
 #endif
+					if (skip_disk_check && res == 0)
+					{
+						freespace = UINT64_MAX;
+					}
 					plist_t freespace_item = plist_new_uint(freespace);
 					mobilebackup2_send_status_response(mobilebackup2, res, NULL, freespace_item);
 					plist_free(freespace_item);


### PR DESCRIPTION
## Summary

- iOS 26 sends inflated backup size estimates during the backup protocol, causing `idevicebackup2` to be rejected with "Insufficient free disk space on drive" even when the host has hundreds of GB free
- Adds a `--skip-disk-check` flag that reports `UINT64_MAX` as free space to the device, bypassing iOS's buggy space validation
- The Hearsay Extractor app performs its own pre-flight space check before invoking `idevicebackup2`, so this is safe

## What's happening

1. iOS sends `DLMessageGetFreeDiskSpace` during backup
2. `idevicebackup2` reports actual host free space (e.g., 348 GB)
3. iOS 26 compares against an inflated backup size estimate (~366 GB for a phone with only 209 GB used)
4. iOS rejects the backup with `ErrorCode: Insufficient free disk space on drive`

## The fix

When `--skip-disk-check` is passed, the `DLMessageGetFreeDiskSpace` handler reports `UINT64_MAX` (~18.4 EB) instead of the real free space. iOS will always consider this sufficient and proceed with the backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)